### PR TITLE
Only update Document when there are changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,11 @@ const connect = (doc, editor) => {
 
 	doc._collectChanges = (cb) => {
 		const newContent = editor.textBuf.getText()
-		doc.update(diff(oldContent, newContent))
-		oldContent = newContent
+		const changes = diff(oldContent, newContent)
+		if (changes.length) {
+		  doc.update(changes)
+		  oldContent = newContent
+		}
 		cb()
 	}
 


### PR DESCRIPTION
There seems to be a bug in the editor-widget code that causes DidChange events to be triggered excessively,
here we make sure that this doesn't flood the gulf link.
