### PR TITLE
Fix: Update cached content in _change method

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const connect = (doc, editor) => {
 
 	doc._change = (changes, cb) => {
 		const newContent = ot.apply(oldContent, changes)
+		oldContent = newContent
 		editor.textBuf.setText(newContent)
 		// todo: transform selection
 		cb()


### PR DESCRIPTION
Here we make sure that the cached content is updated when a remote change comes in, not doing this can also trigger a feedback loop ;)
